### PR TITLE
added support for action links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PROG     =  slider
 VER      =  3.0a
 CC       ?= gcc
 DEFS     =  -DPROGRAM_NAME=${PROG} -DPROGRAM_VER=${VER}
-DEPS		= x11 cairo freetype2 poppler-glib xinerama
+DEPS     = x11 cairo freetype2 poppler-glib xinerama
 CFLAGS   += $(shell pkg-config --cflags ${DEPS}) ${DEFS}
 LDLIBS   += $(shell pkg-config --libs ${DEPS}) -lm
 PREFIX   ?= /usr

--- a/src/config.c
+++ b/src/config.c
@@ -166,4 +166,3 @@ int config_views(XrmDatabase xrdb, const char *base) {
 	}
 	return 0;
 }
-


### PR DESCRIPTION
Hey, I added in support for action links (again!).
I didn't make a conf.launch_handler like you did for url, movie, and audio because all the information in the action launch was self-contained. Although, if you'd prefer it, I can still make things go through conf.launch_handler.
You essentially get the action to launch by ctrl+a or by assigning another key to 'action 2'.
